### PR TITLE
Create tests that detect failing builds

### DIFF
--- a/src/Buildalyzer.Logger/BuildalyzerLogger.cs
+++ b/src/Buildalyzer.Logger/BuildalyzerLogger.cs
@@ -13,7 +13,7 @@ public class BuildalyzerLogger : PipeLogger
     public override void Initialize(IEventSource eventSource)
     {
         // Parse the parameters
-        string[] parameters = Parameters.Split(';').Select(x => x.Trim()).ToArray();
+        string[] parameters = [..(Parameters?.Split(';').Select(x => x.Trim())).OfType<string>()];
         if (parameters.Length != 2)
         {
             throw new LoggerException("Unexpected number of parameters");

--- a/tests/Buildalyzer.Tests/Integration/Failing_builds.cs
+++ b/tests/Buildalyzer.Tests/Integration/Failing_builds.cs
@@ -10,7 +10,7 @@ public class Analyzer_Build
     public void Detects_failing_build_on_single_target()
     {
         using var ctx = Context.ForProject(@"BuildWithError\BuildWithError.csproj");
-        var results = ctx.Analyzer.Build(new EnvironmentOptions());
+        var results = ctx.Analyzer.Build(new EnvironmentOptions() { DesignTime = false });
 
         Console.WriteLine(ctx.Log);
 
@@ -22,7 +22,7 @@ public class Analyzer_Build
     public void Detects_failing_build_on_multi_targets()
     {
         using var ctx = Context.ForProject(@"BuildWithError\BuildWithError.MultiTarget.csproj");
-        var results = ctx.Analyzer.Build(new EnvironmentOptions());
+        var results = ctx.Analyzer.Build(new EnvironmentOptions() { DesignTime = false });
 
         Console.WriteLine(ctx.Log);
 

--- a/tests/Buildalyzer.Tests/Integration/Failing_builds.cs
+++ b/tests/Buildalyzer.Tests/Integration/Failing_builds.cs
@@ -1,0 +1,32 @@
+using Buildalyzer.Environment;
+using Buildalyzer.TestTools;
+using FluentAssertions;
+
+namespace Failing_builds;
+
+public class Analyzer_Build
+{
+    [Test]
+    public void Detects_failing_build_on_single_target()
+    {
+        using var ctx = Context.ForProject(@"BuildWithError\BuildWithError.csproj");
+        var results = ctx.Analyzer.Build(new EnvironmentOptions());
+
+        Console.WriteLine(ctx.Log);
+
+        results.OverallSuccess.Should().BeFalse();
+        results.Should().AllSatisfy(r => r.Succeeded.Should().BeFalse());
+    }
+
+    [Test]
+    public void Detects_failing_build_on_multi_targets()
+    {
+        using var ctx = Context.ForProject(@"BuildWithError\BuildWithError.MultiTarget.csproj");
+        var results = ctx.Analyzer.Build(new EnvironmentOptions());
+
+        Console.WriteLine(ctx.Log);
+
+        results.OverallSuccess.Should().BeFalse();
+        results.Should().AllSatisfy(r => r.Succeeded.Should().BeFalse());
+    }
+}

--- a/tests/Buildalyzer.Workspaces.Tests/Failing_builds.cs
+++ b/tests/Buildalyzer.Workspaces.Tests/Failing_builds.cs
@@ -1,0 +1,17 @@
+using Buildalyzer.TestTools;
+using Buildalyzer.Workspaces;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Failing_builds;
+
+public class Analyzer_Build
+{
+    [Test]
+    public void Detects_failing_build()
+    {
+        using var ctx = Context.ForProject(@"BuildWithError\BuildWithError.csproj");
+
+        ctx.Invoking(c => ctx.Analyzer.GetWorkspace()).Should().NotThrow();
+    }
+}

--- a/tests/projects/BuildWithError/BuildWithError.MultiTarget.csproj
+++ b/tests/projects/BuildWithError/BuildWithError.MultiTarget.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    </PropertyGroup>
+
+</Project>

--- a/tests/projects/BuildWithError/BuildWithError.csproj
+++ b/tests/projects/BuildWithError/BuildWithError.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+
+</Project>

--- a/tests/projects/BuildWithError/MissingSemiColon.cs
+++ b/tests/projects/BuildWithError/MissingSemiColon.cs
@@ -1,0 +1,6 @@
+namespace BuildWithError;
+
+public class MissingSemiColon
+{
+    public string Name { get; set }
+}

--- a/tests/projects/BuildWithError/UnclosedClass.cs
+++ b/tests/projects/BuildWithError/UnclosedClass.cs
@@ -1,0 +1,3 @@
+namespace BuildWithError;
+
+public class UnclosedClass


### PR DESCRIPTION
There is no test coverage - as far as I could find - that detects what happens when a build is failing. I'm not sure if I am doing something wrong, or that although there are compilation errors, the `BuildFinishedEventsArgs` and `TargetFinishedEventsArgs` communicate `Successful = true`.