### PR TITLE
Update packages and add net10.0 target; drop net6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Shared properties">
-    <Version Condition="'$(BuildalyzerVersion)' == ''">1.0.0</Version>
+    <Version Condition="'$(BuildalyzerVersion)' == ''">8.1.0</Version>
     <Version Condition="'$(BuildalyzerVersion)' != ''">$(BuildalyzerVersion)</Version>
     <AssemblyVersion>$(Version.Split('-')[0])</AssemblyVersion>
     <FileVersion>$(Version.Split('-')[0])</FileVersion>
@@ -56,7 +56,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202" PrivateAssets="all"/>
+    <!-- Pin patched version to suppress NU1903 vulnerability warnings (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf).
+         System.Security.Cryptography.Xml 10.0.1 is pulled in transitively on net10.0 targets. -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">

--- a/package.props
+++ b/package.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Build extensions">
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Buildalyzer.Logger/Buildalyzer.Logger.csproj
+++ b/src/Buildalyzer.Logger/Buildalyzer.Logger.csproj
@@ -19,7 +19,7 @@ ToBeReleased
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="14.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.4.0" PrivateAssets="all" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" PrivateAssets="all" IsLogger="true" />
   </ItemGroup>
 

--- a/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
+++ b/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
@@ -3,7 +3,10 @@
   <Import Project="../../package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <!-- Microsoft.Build 18.x and Microsoft.IO.Redist only ship net472 assets; net8+ projects
+         pick them up via the .NETFramework compatibility fallback, which works fine at runtime. -->
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
     <Description>
       A little utility to perform design-time builds of .NET projects without
       having to think too hard about it. This extension library adds support
@@ -23,8 +26,8 @@ ToBeReleased
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Buildalyzer/AnalyzerManager.cs
+++ b/src/Buildalyzer/AnalyzerManager.cs
@@ -50,7 +50,7 @@ public class AnalyzerManager : IAnalyzerManager
 
     [Obsolete("Use AnalyzerManager(IOPath, AnalyzerManagerOptions) instead.")]
     public AnalyzerManager(string solutionFilePath, AnalyzerManagerOptions? options = null)
-        : this(IOPath.Parse(solutionFilePath), options) { }
+        : this(IOPath.Parse(Path.GetFullPath(solutionFilePath)), options) { }
 
     public AnalyzerManager(IOPath solutionFilePath, AnalyzerManagerOptions? options = null)
     {
@@ -100,7 +100,12 @@ public class AnalyzerManager : IAnalyzerManager
             throw new ArgumentException($"The path {binLogPath} could not be found.");
         }
 
-        BinLogReader reader = new BinLogReader();
+        // BinaryLogReplayEventSource (from Microsoft.Build) correctly handles all MSBuild 18.x
+        // event types including AssemblyLoadBuildEventArgs. The StructuredLogger.BinLogReader
+        // stops replaying mid-stream when it encounters unknown event types in newer binlogs,
+        // causing ProjectEvaluationFinishedEventArgs to never fire and leaving _evalulationResults
+        // empty, so ProjectStarted falls back to null propertiesAndItems and no results are produced.
+        var reader = new Microsoft.Build.Logging.BinaryLogReplayEventSource();
 
         using EventProcessor eventProcessor = new EventProcessor(this, null, buildLoggers, reader, true);
         reader.Replay(binLogPath);

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -3,10 +3,13 @@
   <Import Project="../../package.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Buildalyzer</PackageId>
     <PackageValidationBaselineVersion>7.0.1</PackageValidationBaselineVersion>
     <OutputType>library</OutputType>
+    <!-- Microsoft.Build 18.x and Microsoft.IO.Redist only ship net472 assets; net8+ projects
+         pick them up via the .NETFramework compatibility fallback, which works fine at runtime. -->
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased
@@ -20,15 +23,15 @@ ToBeReleased
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.14.28" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.28" />
+    <PackageReference Include="Microsoft.Build" Version="18.4.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4,)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="[4,)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.158" Aliases="StructuredLogger" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.3.154" Aliases="StructuredLogger" />
     <PackageReference Include="MsBuildPipeLogger.Server" Version="1.1.6" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.9.1" />
+    <PackageReference Include="NuGet.Frameworks" Version="7.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Buildalyzer/Logging/EventProcessor.cs
+++ b/src/Buildalyzer/Logging/EventProcessor.cs
@@ -83,8 +83,12 @@ internal class EventProcessor : IDisposable
         // Make sure this is the same project, nested MSBuild tasks may have spawned additional builds of other projects
         if (AnalyzerManager.NormalizePath(e.ProjectFile) == _projectFilePath)
         {
-            // Get the items and properties from the evaluation if needed
-            PropertiesAndItems propertiesAndItems = e.Properties is null
+            // Get the items and properties from the evaluation if needed.
+            // Treat an empty e.Properties the same as null: BinLogReader (MSBuild.StructuredLogger)
+            // creates ProjectStartedEventArgs with Properties set to a non-null but empty collection
+            // rather than null for binlog format 14+ events.  The empty collection carries no useful
+            // data, so fall back to the evaluation-phase results just as we do when Properties is null.
+            PropertiesAndItems propertiesAndItems = e.Properties is null || !e.Properties.Cast<object>().Any()
                 ? (_evalulationResults.TryGetValue(e.BuildEventContext.EvaluationId, out PropertiesAndItems evaluationResult)
                     ? evaluationResult
                     : null)

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -374,6 +374,99 @@ public class SimpleProjectsFixture
         references.ShouldContain(x => x.EndsWith("SdkNetStandardProject.csproj"), log.ToString());
     }
 
+    /// <summary>
+    /// Regression test for the bug where ProjectReferences are empty when an analysis result
+    /// is obtained by replaying a binlog via <see cref="IAnalyzerManager.Analyze"/>.
+    ///
+    /// Root cause: <see cref="Buildalyzer.Logging.EventProcessor"/> checks
+    /// <c>e.Properties is null</c> to detect the "new-format" binlog (format 14+) and fall
+    /// back to evaluation-phase items. However, <c>BinLogReader</c> from
+    /// MSBuild.StructuredLogger creates <c>ProjectStartedEventArgs</c> with
+    /// <c>Properties</c> set to an empty non-null collection rather than <c>null</c>,
+    /// so the check always resolves to the old-format path — using the empty
+    /// <c>e.Properties</c>/<c>e.Items</c> instead of the populated evaluation results.
+    /// The fix is to treat an empty <c>e.Properties</c> the same as null.
+    /// </summary>
+    [Test]
+    public void SdkProjectWithProjectReferenceGetsReferencesFromBinaryLog(
+        [ValueSource(nameof(Preferences))] EnvironmentPreference preference)
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetCore2ProjectWithReference\SdkNetCore2ProjectWithReference.csproj", log);
+        EnvironmentOptions options = new EnvironmentOptions { Preference = preference };
+        string binLogPath = Path.ChangeExtension(Path.GetTempFileName(), ".binlog");
+        analyzer.AddBinaryLogger(binLogPath);
+
+        try
+        {
+            // When — build to produce the binlog, then replay it
+            analyzer.Build(options);
+            IAnalyzerResults results = analyzer.Manager.Analyze(binLogPath);
+
+            // Then — ProjectReferences must survive the binlog round-trip
+            IEnumerable<string> references = results.First(r => r.Succeeded).ProjectReferences;
+            references.ShouldNotBeNull(log.ToString());
+            references.ShouldContain(x => x.EndsWith("SdkNetStandardProjectWithPackageReference.csproj"), log.ToString());
+            references.ShouldContain(x => x.EndsWith("SdkNetStandardProject.csproj"), log.ToString());
+        }
+        finally
+        {
+            if (File.Exists(binLogPath))
+            {
+                File.Delete(binLogPath);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Regression test using the child-side <c>/bl:</c> argument (as opposed to host-side
+    /// <see cref="IProjectAnalyzer.AddBinaryLogger"/>). When the binlog is produced by passing
+    /// <c>/bl:path</c> inside <see cref="EnvironmentOptions.Arguments"/>, MSBuild writes
+    /// it from the build process itself.  Replaying that log via
+    /// <see cref="IAnalyzerManager.Analyze"/> triggers the
+    /// <c>BinLogReader</c> path in <c>EventProcessor</c> where
+    /// <c>ProjectStartedEventArgs.Properties</c> is a non-null but empty collection.
+    /// Because <see cref="Logging.EventProcessor"/> checks <c>e.Properties is null</c>
+    /// it never falls back to the evaluation-phase items, leaving
+    /// <c>ProjectReferences</c> empty.
+    /// </summary>
+    [Test]
+    public void SdkProjectWithProjectReferenceGetsReferencesFromChildSideBinaryLog(
+        [ValueSource(nameof(Preferences))] EnvironmentPreference preference)
+    {
+        // Given
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(@"SdkNetCore2ProjectWithReference\SdkNetCore2ProjectWithReference.csproj", log);
+        string binLogPath = Path.ChangeExtension(Path.GetTempFileName(), ".binlog");
+        EnvironmentOptions options = new EnvironmentOptions
+        {
+            Preference = preference
+        };
+        // Child-side binary logging: the build process itself writes the binlog
+        options.Arguments.Add($"/bl:{binLogPath}");
+
+        try
+        {
+            // When — build to produce the binlog, then replay it
+            analyzer.Build(options);
+            IAnalyzerResults results = analyzer.Manager.Analyze(binLogPath);
+
+            // Then — ProjectReferences must survive the child-side binlog round-trip
+            IEnumerable<string> references = results.First(r => r.Succeeded).ProjectReferences;
+            references.ShouldNotBeNull(log.ToString());
+            references.ShouldContain(x => x.EndsWith("SdkNetStandardProjectWithPackageReference.csproj"), log.ToString());
+            references.ShouldContain(x => x.EndsWith("SdkNetStandardProject.csproj"), log.ToString());
+        }
+        finally
+        {
+            if (File.Exists(binLogPath))
+            {
+                File.Delete(binLogPath);
+            }
+        }
+    }
+
     [Test]
     public void SdkProjectWithDefineContstantsGetsPreprocessorSymbols()
     {

--- a/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
+++ b/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Drop `net6.0` target, add `net10.0` to `Buildalyzer` and `Buildalyzer.Workspaces`
- Update MSBuild packages to 18.4.0 (aligns with the .NET 10 SDK)
- Update `MSBuild.StructuredLogger` to 2.3.154 (required to parse binlog format 25 produced by MSBuild 18.x)
- Update Roslyn, NuGet, logging, and test packages to current releases
- Bump version to 8.1.0
- Suppress `NU1701` for net8+/net10 consumers of MSBuild 18.x (which only ships `net472` assets but works fine via compatibility fallback)
- Pin `System.Security.Cryptography.Xml` 10.0.6 to clear `NU1903` vulnerability warnings

## Dependencies

- Buildalyzer/Buildalyzer#329 — the binlog/path fix PR should land first since this PR builds on that branch

## Test plan

- [ ] All existing integration tests pass on net8.0 and net10.0
- [ ] No NU1701 or NU1903 warnings in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)