### PR TITLE
Target .NET 10 with CPM

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,36 +1,46 @@
 <Project>
 
-  <PropertyGroup>
-    <RepositoryUrl>https://github.com/phmonte/Buildalyzer.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  <PropertyGroup Label="Core compilation settings">
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <OutputType>library</OutputType>
+    <LangVersion>14.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+  
+  <PropertyGroup Label="Analaysis">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <NuGetAuditMode>all</NuGetAuditMode>
+  </PropertyGroup>
+  
+  <PropertyGroup Label="Debug experience">
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <DebugType>portable</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Label="Shared properties">
+  <PropertyGroup Label="Versioning">
     <Version Condition="'$(BuildalyzerVersion)' == ''">1.0.0</Version>
     <Version Condition="'$(BuildalyzerVersion)' != ''">$(BuildalyzerVersion)</Version>
     <AssemblyVersion>$(Version.Split('-')[0])</AssemblyVersion>
     <FileVersion>$(Version.Split('-')[0])</FileVersion>
-    <LangVersion>12</LangVersion>
-    <Nullable>enable</Nullable>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <NuGetAuditMode>all</NuGetAuditMode>
-    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
+    <DefineConstants>Is_Windows</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Label="Package information">
     <ProductName>Buildalyzer</ProductName>
     <Description>
+      <![CDATA[
       A little utility to perform design-time builds of .NET projects without
       having to think too hard about it. Should work with any project type on
       any .NET runtime.
+      ]]>
     </Description>
     <PackageTags>
       Roslyn,
@@ -43,10 +53,16 @@
     <Authors>Dave Glick, Pablo Monteiro, Corniel Nobel, and contributors</Authors>
     <Company>Dave Glick, Pablo Monteiro, and contributors</Company>
     <Copyright>Dave Glick, Pablo Monteiro</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageIcon>icon.png</PackageIcon>
     <PackageIconUrl>https://github.com/phmonte/Buildalyzer/blob/main/icon.png</PackageIconUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/phmonte/Buildalyzer</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/phmonte/Buildalyzer.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,13 +8,13 @@
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
-  
+
   <PropertyGroup Label="Analaysis">
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <NuGetAuditMode>all</NuGetAuditMode>
   </PropertyGroup>
-  
+
   <PropertyGroup Label="Debug experience">
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -29,7 +29,7 @@
     <FileVersion>$(Version.Split('-')[0])</FileVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
+  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
     <DefineConstants>Is_Windows</DefineConstants>
   </PropertyGroup>
 
@@ -71,22 +71,27 @@
     <None Include="$(MSBuildThisFileDirectory)/README.md" Pack="true" PackagePath="/"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
+  <ItemGroup Label="Build dependencies">
+    <PackageReference PrivateAssets="all" Include="Microsoft.Sbom.Targets" />
+    <PackageReference PrivateAssets="all" Include="Microsoft.SourceLink.GitHub" />
+    <PackageReference PrivateAssets="all" Include="PolySharp" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" />
-    <PackageReference Include="IDisposableAnalyzers" Version="*" PrivateAssets="all"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="*" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="*" PrivateAssets="all"/>
-    <PackageReference Include="Roslynator.Analyzers" Version="*" PrivateAssets="all"/>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="*" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="*-*" PrivateAssets="all"/>
+    <PackageReference PrivateAssets="all" Include="DotNetProjectFile.Analyzers" />
+    <PackageReference PrivateAssets="all" Include="Microsoft.CodeAnalysis.Analyzers" />
+    <PackageReference PrivateAssets="all" Include="Microsoft.VisualStudio.Threading.Analyzers" />
+    <PackageReference PrivateAssets="all" Include="Roslynator.Analyzers" />
+    <PackageReference PrivateAssets="all" Include="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
-  <ItemGroup Label="Additional files">
-    <AdditionalFiles Include="*.csproj" Visible="false" />
+  <!-- Prepare for CPM -->
+  <ItemGroup Label="Versions">
+    <PackageReference Update="DotNetProjectFile.Analyzers" Version="1.11.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.0" />
+    <PackageReference Update="Roslynator.Analyzers" Version="4.15.0" />
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="10.23.0.137933" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,13 +85,4 @@
     <PackageReference PrivateAssets="all" Include="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
-  <!-- Prepare for CPM -->
-  <ItemGroup Label="Versions">
-    <PackageReference Update="DotNetProjectFile.Analyzers" Version="1.11.0" />
-    <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.0" />
-    <PackageReference Update="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageReference Update="SonarAnalyzer.CSharp" Version="10.23.0.137933" />
-  </ItemGroup>
-
 </Project>

--- a/buildalyzer.slnx
+++ b/buildalyzer.slnx
@@ -10,6 +10,7 @@
     <File Path="package.props" />
     <File Path="RELEASE.md" />
     <File Path="stylecop.json" />
+    <File Path="versions.props" />
   </Folder>
   <Folder Name="/Solution Items/.github/">
     <File Path=".github/FUNDING.yml" />

--- a/package.props
+++ b/package.props
@@ -15,7 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup Label="Build extensions">
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.4" PrivateAssets="all" />
+    <PackageReference PrivateAssets="all" Include="IDisposableAnalyzers" />
+    <PackageReference PrivateAssets="all" Include="StyleCop.Analyzers.Unstable" />
   </ItemGroup>
 
 </Project>

--- a/src/Buildalyzer.Logger/Buildalyzer.Logger.csproj
+++ b/src/Buildalyzer.Logger/Buildalyzer.Logger.csproj
@@ -3,13 +3,12 @@
   <Import Project="../../package.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <Description>The MSBuild logger for Buildalyzer. Not intended to be used directly.</Description>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);PackLogger</TargetsForTfmSpecificBuildOutput>
     <PackageId>Buildalyzer.Logger</PackageId>
     <PackageValidationBaselineVersion>8.0.0</PackageValidationBaselineVersion>
-    <OutputType>library</OutputType>
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased

--- a/src/Buildalyzer.Logger/Buildalyzer.Logger.csproj
+++ b/src/Buildalyzer.Logger/Buildalyzer.Logger.csproj
@@ -18,8 +18,8 @@ ToBeReleased
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="14.3.0" PrivateAssets="all" />
-    <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" PrivateAssets="all" IsLogger="true" />
+    <PackageReference PrivateAssets="all" Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference PrivateAssets="all" Include="MsBuildPipeLogger.Logger" IsLogger="true" />
   </ItemGroup>
 
   <!-- Get the logger files for later use -->
@@ -30,13 +30,16 @@ ToBeReleased
     <Error Condition="'@(LoggerFiles)' == ''" Text="Could not find MsBuildPipeLogger.Logger files" />
   </Target>
 
-  <!-- Workaround to pack package reference directly -->
-  <!-- See https://github.com/NuGet/Home/issues/3891 -->
-  <!-- And https://github.com/NuGet/Home/issues/4837 -->
+  <!--
+    Workaround to pack package reference directly 
+    See https://github.com/NuGet/Home/issues/3891
+    And https://github.com/NuGet/Home/issues/4837 -->
   <Target Name="PackLogger" DependsOnTargets="GetLoggerFiles">
     <ItemGroup>
       <BuildOutputInPackage Include="@(LoggerFiles)" />
     </ItemGroup>
   </Target>
+
+  <Import Project="../../versions.props" />
 
 </Project>

--- a/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
+++ b/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
@@ -4,9 +4,11 @@
 
   <PropertyGroup>
     <Description>
+      <![CDATA[
       A little utility to perform design-time builds of .NET projects without
       having to think too hard about it. This extension library adds support
       for creating a Roslyn workspace from Buildalyzer.
+      ]]>
     </Description>
     <PackageId>Buildalyzer.Workspaces</PackageId>
     <PackageValidationBaselineVersion>8.0.0</PackageValidationBaselineVersion>
@@ -21,12 +23,14 @@ ToBeReleased
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../Buildalyzer/Buildalyzer.csproj" />
   </ItemGroup>
 
+  <Import Project="../../versions.props" />
+  
 </Project>

--- a/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
+++ b/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
@@ -23,8 +23,8 @@ ToBeReleased
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version ="4.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version ="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
+++ b/src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj
@@ -3,7 +3,6 @@
   <Import Project="../../package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <Description>
       A little utility to perform design-time builds of .NET projects without
       having to think too hard about it. This extension library adds support
@@ -11,7 +10,6 @@
     </Description>
     <PackageId>Buildalyzer.Workspaces</PackageId>
     <PackageValidationBaselineVersion>8.0.0</PackageValidationBaselineVersion>
-    <OutputType>library</OutputType>
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -27,6 +27,7 @@ ToBeReleased
     <PackageReference Include="MSBuild.StructuredLogger" Aliases="StructuredLogger" />
     <PackageReference Include="MsBuildPipeLogger.Server" />
     <PackageReference Include="NuGet.Frameworks" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -1,13 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../package.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-    <LangVersion>14.0</LangVersion>
     <PackageId>Buildalyzer</PackageId>
     <PackageValidationBaselineVersion>8.0.0</PackageValidationBaselineVersion>
-    <OutputType>library</OutputType>
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -20,8 +20,8 @@ ToBeReleased
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4,)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="[4,)" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
     <PackageReference Include="MSBuild.StructuredLogger" Aliases="StructuredLogger" />

--- a/src/Buildalyzer/Buildalyzer.csproj
+++ b/src/Buildalyzer/Buildalyzer.csproj
@@ -18,21 +18,17 @@ ToBeReleased
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.14.28" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.28" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4,)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="[4,)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.158" Aliases="StructuredLogger" />
-    <PackageReference Include="MsBuildPipeLogger.Server" Version="1.1.6" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.9.1" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
+    <PackageReference Include="MSBuild.StructuredLogger" Aliases="StructuredLogger" />
+    <PackageReference Include="MsBuildPipeLogger.Server" />
+    <PackageReference Include="NuGet.Frameworks" />
   </ItemGroup>
-
-  <ItemGroup Label="Build dependencies">
-    <PackageReference PrivateAssets="all" Include="PolySharp" Version="1.15.0" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Buildalyzer.Tests</_Parameter1>
@@ -46,4 +42,6 @@ ToBeReleased
     <ProjectReference Include="../Buildalyzer.Logger/Buildalyzer.Logger.csproj" />
   </ItemGroup>
 
+  <Import Project="../../versions.props" />
+  
 </Project>

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
@@ -6,7 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup Label="Test versions">
-    <PackageReference Include="FSharp.Compiler.Service"  />
+    <PackageReference Include="FSharp.Compiler.Service" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="4.*" />
+    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic" Version="4.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -6,31 +6,31 @@
   </PropertyGroup>
 
   <ItemGroup Label="Test versions">
-    <PackageReference Include="FSharp.Compiler.Service" Version="*" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="4.*" />
-    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic" Version="4.*" />
+    <PackageReference Include="FSharp.Compiler.Service"  />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="LibGit2Sharp" />
+    <PackageReference Include="MsBuildPipeLogger.Logger" GeneratePathProperty="true" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="Shouldly"  />
   </ItemGroup>
 
   <ItemGroup Label="Build tools">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" PrivateAssets="all" />
-    <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
+    <PackageReference PrivateAssets="all" Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference PrivateAssets="all" Include="NUnit3TestAdapter" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8" PrivateAssets="all" />
-    <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="all" />
+    <PackageReference PrivateAssets="all" Include="AwesomeAssertions.Analyzers" />
+    <PackageReference PrivateAssets="all" Include="NUnit.Analyzers" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../src/Buildalyzer/Buildalyzer.csproj" />
   </ItemGroup>
+
+  <Import Project="../../versions.props" />
 
 </Project>

--- a/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
+++ b/tests/Buildalyzer.Tests/Buildalyzer.Tests.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
-    <OutputType>library</OutputType>
   </PropertyGroup>
 
   <ItemGroup Label="Test versions">
@@ -16,7 +14,6 @@
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-    
     <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
@@ -35,9 +32,5 @@
   <ItemGroup>
     <ProjectReference Include="../../src/Buildalyzer/Buildalyzer.csproj" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
-    <DefineConstants>Is_Windows</DefineConstants>
-  </PropertyGroup>
 
 </Project>

--- a/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
+++ b/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
-    <OutputType>library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,7 +17,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
-
   <ItemGroup Label="Analyzers">
     <PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8" PrivateAssets="all" />
     <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="all" />
@@ -29,9 +26,5 @@
     <ProjectReference Include="../../src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj" />
     <ProjectReference Include="../Buildalyzer.Tests/Buildalyzer.Tests.csproj" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
-    <DefineConstants>Is_Windows</DefineConstants>
-  </PropertyGroup>
 
 </Project>

--- a/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
+++ b/tests/Buildalyzer.Workspaces.Tests/Buildalyzer.Workspaces.Tests.csproj
@@ -6,25 +6,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
-    <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.6" GeneratePathProperty="true" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="MsBuildPipeLogger.Logger" GeneratePathProperty="true" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup Label="Build tools">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" PrivateAssets="all" />
-    <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
+    <PackageReference PrivateAssets="all" Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference PrivateAssets="all" Include="NUnit3TestAdapter" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8" PrivateAssets="all" />
-    <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="all" />
+    <PackageReference PrivateAssets="all" Include="AwesomeAssertions.Analyzers" />
+    <PackageReference PrivateAssets="all" Include="NUnit.Analyzers" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../src/Buildalyzer.Workspaces/Buildalyzer.Workspaces.csproj" />
     <ProjectReference Include="../Buildalyzer.Tests/Buildalyzer.Tests.csproj" />
   </ItemGroup>
+
+  <Import Project="../../versions.props" />
 
 </Project>

--- a/tests/projects/Directory.Build.props
+++ b/tests/projects/Directory.Build.props
@@ -1,7 +1,2 @@
 <!-- empty Directory.Build.props to reset and not use props from root -->
-<Project> 
-  <PropertyGroup>
-  </PropertyGroup>
-  <ItemGroup>
-  </ItemGroup>
-</Project>
+<Project /> 

--- a/tests/projects/Directory.Packages.props
+++ b/tests/projects/Directory.Packages.props
@@ -1,0 +1,2 @@
+<!-- empty Directory.Packages.props to reset and not use props from root -->
+<Project />

--- a/versions.props
+++ b/versions.props
@@ -1,22 +1,21 @@
 <Project>
   <!-- Prepare for CPM -->
   <ItemGroup>
-    <PackageReference Update="SonarAnalyzer.CSharp" Version="10.23.0.137933" />
     <PackageReference Update="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Update="AwesomeAssertions.Analyzers" Version="9.0.8" />
     <PackageReference Update="DotNetProjectFile.Analyzers" Version="1.11.0" />
     <PackageReference Update="IDisposableAnalyzers" Version="4.0.8" />
     <PackageReference Update="FSharp.Compiler.Service" Version="43.12.202" />
     <PackageReference Update="LibGit2Sharp" Version="0.31.0" />
-    <PackageReference Update="Microsoft.Build" Version="17.14.28" />
-    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="17.14.28" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="14.3.0" />
+    <PackageReference Update="Microsoft.Build" Version="18.4.0" />
+    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="18.4.0" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="18.4.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="[4.10,)" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.10,)" />
     <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="[4.10,)" />
     <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic" Version="[4.10,)" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Version="10.0.6" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Update="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
@@ -32,6 +31,8 @@
     <PackageReference Update="PolySharp" Version="1.15.0" />
     <PackageReference Update="Roslynator.Analyzers" Version="4.15.0" />
     <PackageReference Update="Shouldly" Version="4.3.0" />
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="10.23.0.137933" />
     <PackageReference Update="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
+    <PackageReference Update="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 </Project>

--- a/versions.props
+++ b/versions.props
@@ -11,10 +11,10 @@
     <PackageReference Update="Microsoft.Build.Tasks.Core" Version="18.4.0" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="18.4.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="[4.10,)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.10,)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="[4.10,)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic" Version="[4.10,)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="[5.0,)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[5.0,)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="[5.0,)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic" Version="[5.0,)" />
     <PackageReference Update="Microsoft.Extensions.Logging" Version="10.0.6" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Update="Microsoft.Sbom.Targets" Version="4.1.5" />

--- a/versions.props
+++ b/versions.props
@@ -1,13 +1,17 @@
 <Project>
+  <!-- Prepare for CPM -->
   <ItemGroup>
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="10.23.0.137933" />
     <PackageReference Update="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Update="AwesomeAssertions.Analyzers" Version="9.0.8" />
+    <PackageReference Update="DotNetProjectFile.Analyzers" Version="1.11.0" />
     <PackageReference Update="IDisposableAnalyzers" Version="4.0.8" />
     <PackageReference Update="FSharp.Compiler.Service" Version="43.12.202" />
     <PackageReference Update="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Update="Microsoft.Build" Version="17.14.28" />
     <PackageReference Update="Microsoft.Build.Tasks.Core" Version="17.14.28" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="14.3.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="[4.10,)" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.10,)" />
     <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="[4.10,)" />
@@ -15,16 +19,18 @@
     <PackageReference Update="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Update="Microsoft.Sbom.Targets" Version="4.1.5" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.202" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <PackageReference Update="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
-    <PackageReference Update="MSBuild.StructuredLogger" Version="2.2.158" />
+    <PackageReference Update="MSBuild.StructuredLogger" Version="2.3.154" />
     <PackageReference Update="MsBuildPipeLogger.Logger" Version="1.1.6" />
     <PackageReference Update="MsBuildPipeLogger.Server" Version="1.1.6" />
-    <PackageReference Update="NuGet.Frameworks" Version="6.9.1" />
+    <PackageReference Update="NuGet.Frameworks" Version="7.3.1" />
     <PackageReference Update="NUnit" Version="4.5.1" />
     <PackageReference Update="NUnit.Analyzers" Version="4.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Update="PolySharp" Version="1.15.0" />
+    <PackageReference Update="Roslynator.Analyzers" Version="4.15.0" />
     <PackageReference Update="Shouldly" Version="4.3.0" />
     <PackageReference Update="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/versions.props
+++ b/versions.props
@@ -11,10 +11,6 @@
     <PackageReference Update="Microsoft.Build.Tasks.Core" Version="18.4.0" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="18.4.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="[5.0,)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[5.0,)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="[5.0,)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic" Version="[5.0,)" />
     <PackageReference Update="Microsoft.Extensions.Logging" Version="10.0.6" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Update="Microsoft.Sbom.Targets" Version="4.1.5" />

--- a/versions.props
+++ b/versions.props
@@ -1,0 +1,31 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Update="AwesomeAssertions" Version="9.4.0" />
+    <PackageReference Update="AwesomeAssertions.Analyzers" Version="9.0.8" />
+    <PackageReference Update="IDisposableAnalyzers" Version="4.0.8" />
+    <PackageReference Update="FSharp.Compiler.Service" Version="43.12.202" />
+    <PackageReference Update="LibGit2Sharp" Version="0.31.0" />
+    <PackageReference Update="Microsoft.Build" Version="17.14.28" />
+    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="17.14.28" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="14.3.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="[4.10,)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.10,)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="[4.10,)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic" Version="[4.10,)" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Update="Microsoft.Sbom.Targets" Version="4.1.5" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
+    <PackageReference Update="MSBuild.StructuredLogger" Version="2.2.158" />
+    <PackageReference Update="MsBuildPipeLogger.Logger" Version="1.1.6" />
+    <PackageReference Update="MsBuildPipeLogger.Server" Version="1.1.6" />
+    <PackageReference Update="NuGet.Frameworks" Version="6.9.1" />
+    <PackageReference Update="NUnit" Version="4.5.1" />
+    <PackageReference Update="NUnit.Analyzers" Version="4.12.0" />
+    <PackageReference Update="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Update="PolySharp" Version="1.15.0" />
+    <PackageReference Update="Shouldly" Version="4.3.0" />
+    <PackageReference Update="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
As we should not deploy breaking changes every day, I think we should not drop .NET 6 (yet).

- [x] .NET 10 targets
- [x] Enable `<EnforceCodeStyleInBuild>` (Roslyn's IDE rules) 
- [ ] Central Package Management
- [ ] Use lock files
- [x] Update packages with security Issues
- [x] Include PolySharp