### PR TITLE
Run restore once, unpinned, instead of per-TFM with TargetFramework set (#346)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 
 ## Other changes
 
+- NuGet restore no longer runs with the `TargetFramework` global property pinned. Builds that pin a target framework (multi-targeted projects built without a specific TFM, and the `Build(targetFramework)` overloads) now restore in a single separate up-front `Restore`-target invocation without `TargetFramework`, instead of passing `-restore` to each pinned build. Restore is a per-project (outer build) operation: pinned restores executed the inner build's restore, producing a single-framework assets file, and re-ran restore once per framework (#346). Builds without a pinned target framework still use `-restore`. When a `BinaryLogger` is attached, the separate restore invocation writes a `.restore`-suffixed binlog (e.g. `project.restore.binlog`).
 - When a multi-targeted project is built without a specific TFM and a `BinaryLogger` is attached, each per-TFM build writes to a TFM-suffixed binlog path (e.g. `project.net8.0.binlog`) so the builds don't overwrite one another (#348).
 - Made the `NonExistentFile` workaround unconditional so `CoreCompile` reliably re-runs and `Csc` emits its command-line event regardless of which targets the caller specifies, matching Roslyn's `MSBuildWorkspace` (#348).
 

--- a/src/Buildalyzer/Environment/BuildEnvironment.cs
+++ b/src/Buildalyzer/Environment/BuildEnvironment.cs
@@ -31,8 +31,14 @@ public sealed class BuildEnvironment
     public bool DesignTime { get; }
 
     /// <summary>
-    /// Runs the restore target prior to any other targets using the MSBuild <c>restore</c> switch.
+    /// Runs the restore target prior to any other targets.
     /// </summary>
+    /// <remarks>
+    /// Builds without a pinned target framework use the MSBuild <c>-restore</c> switch.
+    /// Builds that pin the <c>TargetFramework</c> global property can't restore themselves
+    /// (restore is a per-project operation that must run on the outer build), so
+    /// <see cref="ProjectAnalyzer"/> runs restore as a separate up-front invocation instead.
+    /// </remarks>
     public bool Restore { get; }
 
     public string[] TargetsToBuild { get; }
@@ -141,5 +147,27 @@ public sealed class BuildEnvironment
             Arguments,
             _additionalGlobalProperties,
             _additionalEnvironmentVariables,
-            WorkingDirectory);
+            WorkingDirectory)
+    {
+        NoAutoResponse = NoAutoResponse,
+    };
+
+    /// <summary>
+    /// Clones the build environment with a different <see cref="Restore"/> setting.
+    /// </summary>
+    /// <param name="restore">Whether the restore target should run prior to any other targets.</param>
+    /// <returns>A new build environment with the specified restore setting.</returns>
+    public BuildEnvironment WithRestore(bool restore) => new(
+            DesignTime,
+            restore,
+            TargetsToBuild,
+            MsBuildExePath,
+            DotnetExePath,
+            Arguments,
+            _additionalGlobalProperties,
+            _additionalEnvironmentVariables,
+            WorkingDirectory)
+    {
+        NoAutoResponse = NoAutoResponse,
+    };
 }

--- a/src/Buildalyzer/Environment/EnvironmentOptions.cs
+++ b/src/Buildalyzer/Environment/EnvironmentOptions.cs
@@ -34,10 +34,17 @@ public class EnvironmentOptions
     public bool DesignTime { get; set; } = true;
 
     /// <summary>
-    /// Runs the restore target prior to any other targets using the MSBuild <c>restore</c> switch.
+    /// Runs the restore target prior to any other targets. The default is <c>true</c>.
+    /// Set to <c>false</c> when the project is already restored externally
+    /// (e.g. <c>dotnet restore</c> on the solution).
     /// </summary>
     /// <remarks>
-    /// See https://github.com/Microsoft/msbuild/pull/2414.
+    /// Builds without a pinned target framework use the MSBuild <c>-restore</c> switch
+    /// (see https://github.com/Microsoft/msbuild/pull/2414). Builds that pin the
+    /// <c>TargetFramework</c> global property (multi-targeted projects and the
+    /// <c>Build(targetFramework)</c> overloads) restore in a separate up-front invocation
+    /// without <c>TargetFramework</c> instead, since restore is a per-project operation
+    /// whose assets file must cover every target framework (#346).
     /// </remarks>
     public bool Restore { get; set; } = true;
 

--- a/src/Buildalyzer/ProjectAnalyzer.cs
+++ b/src/Buildalyzer/ProjectAnalyzer.cs
@@ -84,15 +84,28 @@ public class ProjectAnalyzer : IProjectAnalyzer
             targetFrameworks = [null];
         }
 
-        // Create a new build environment for each target.
-        // Note that restore must run per iteration: restoring with the TargetFramework
-        // global property pinned produces an assets file for that framework only.
         AnalyzerResults results = [];
         bool perTfmBinlog = targetFrameworks.Length > 1;
+
+        // Builds that pin a target framework can't restore themselves (see Restore), so run
+        // a single up-front restore with the project's own (outer) build environment. It
+        // produces an assets file covering every framework, so one restore is enough.
+        bool restore = environmentOptions.Restore && targetFrameworks.Any(t => t is not null);
+        if (restore && !Restore(EnvironmentFactory.GetBuildEnvironment(null, environmentOptions), results))
+        {
+            return results;
+        }
+
+        // Create a new build environment for each target
         foreach (string targetFramework in targetFrameworks)
         {
             BuildEnvironment buildEnvironment = EnvironmentFactory.GetBuildEnvironment(targetFramework, environmentOptions);
-            using (WithPerTfmBinaryLogPaths(targetFramework, perTfmBinlog))
+            if (restore)
+            {
+                buildEnvironment = buildEnvironment.WithRestore(false);
+            }
+
+            using (WithSuffixedBinaryLogPaths(targetFramework, perTfmBinlog))
             {
                 BuildTargets(buildEnvironment, targetFramework, buildEnvironment.TargetsToBuild, results);
             }
@@ -114,9 +127,21 @@ public class ProjectAnalyzer : IProjectAnalyzer
 
         AnalyzerResults results = [];
         bool perTfmBinlog = targetFrameworks.Length > 1;
+
+        // Builds that pin a target framework can't restore themselves (see Restore), so run
+        // a single up-front restore covering every framework.
+        if (buildEnvironment.Restore && targetFrameworks.Any(t => t is not null))
+        {
+            if (!Restore(buildEnvironment, results))
+            {
+                return results;
+            }
+            buildEnvironment = buildEnvironment.WithRestore(false);
+        }
+
         foreach (string targetFramework in targetFrameworks)
         {
-            using (WithPerTfmBinaryLogPaths(targetFramework, perTfmBinlog))
+            using (WithSuffixedBinaryLogPaths(targetFramework, perTfmBinlog))
             {
                 BuildTargets(buildEnvironment, targetFramework, buildEnvironment.TargetsToBuild, results);
             }
@@ -125,12 +150,44 @@ public class ProjectAnalyzer : IProjectAnalyzer
         return results;
     }
 
-    // When invoking multiple per-TFM builds in succession, point any attached
-    // BinaryLogger at a TFM-suffixed path so each iteration's binlog isn't
-    // overwritten by the next. The original path is restored on dispose.
-    private IDisposable WithPerTfmBinaryLogPaths(string? targetFramework, bool active)
+    // Restore is a per-project operation that belongs to the outer build: restoring with the
+    // TargetFramework global property pinned executes the inner build's restore instead,
+    // writing an assets file that covers only that framework and breaking any other
+    // framework's build with NETSDK1005 (#346). So builds that pin a target framework never
+    // use the -restore switch; the Restore target runs in this separate up-front invocation
+    // that doesn't pin TargetFramework. Builds without a pinned target framework keep using
+    // -restore in the build invocation itself, which already restores the outer build.
+    // Returns whether the restore succeeded; callers short-circuit on failure rather than
+    // running builds that would only fail with a misleading (e.g. NETSDK1005) error.
+    private bool Restore(BuildEnvironment buildEnvironment, AnalyzerResults results)
     {
-        if (!active || targetFramework is null)
+        AnalyzerResults restoreResults = [];
+        using (WithSuffixedBinaryLogPaths("restore", true))
+        {
+            BuildTargets(buildEnvironment.WithRestore(false), null, ["Restore"], restoreResults);
+        }
+
+        // Only carry over the success flag: the restore invocation's evaluation would
+        // otherwise surface as an extra (empty) target framework result.
+        results.Add([], restoreResults.OverallSuccess);
+
+        // On failure the caller stops before any build overwrites BuildEventArguments, so
+        // carry the restore's events across to surface the actual restore diagnostics.
+        if (!restoreResults.OverallSuccess)
+        {
+            results.BuildEventArguments = restoreResults.BuildEventArguments;
+        }
+
+        return restoreResults.OverallSuccess;
+    }
+
+    // When invoking multiple builds in succession (per-TFM builds, or a restore preceding
+    // them), point any attached BinaryLogger at a suffixed path (e.g. the TFM or "restore")
+    // so each invocation's binlog isn't overwritten by the next. The original path is
+    // restored on dispose.
+    private IDisposable WithSuffixedBinaryLogPaths(string? suffix, bool active)
+    {
+        if (!active || suffix is null)
         {
             return NullScope.Instance;
         }
@@ -140,7 +197,7 @@ public class ProjectAnalyzer : IProjectAnalyzer
         {
             string original = logger.Parameters;
             snapshots.Add((logger, original));
-            logger.Parameters = AddTargetFrameworkToBinaryLogPath(original, targetFramework);
+            logger.Parameters = AddSuffixToBinaryLogPath(original, suffix);
         }
 
         return new RestoreBinaryLogPaths(snapshots);
@@ -149,7 +206,7 @@ public class ProjectAnalyzer : IProjectAnalyzer
     // BinaryLogger.Parameters is a semicolon-separated list where the log file is either a
     // bare path ending in ".binlog" or a "LogFile=" segment (possibly quoted), alongside
     // other segments like "ProjectImports=Embed". Only the log file segment is rewritten.
-    internal static string AddTargetFrameworkToBinaryLogPath(string parameters, string targetFramework)
+    internal static string AddSuffixToBinaryLogPath(string parameters, string suffix)
     {
         if (string.IsNullOrEmpty(parameters))
         {
@@ -176,7 +233,7 @@ public class ProjectAnalyzer : IProjectAnalyzer
             string quote = path.Length == segment.Length ? string.Empty : "\"";
             string extension = Path.GetExtension(path);
             string withoutExtension = Path.ChangeExtension(path, null);
-            segments[i] = $"{prefix}{quote}{withoutExtension}.{targetFramework}{extension}{quote}";
+            segments[i] = $"{prefix}{quote}{withoutExtension}.{suffix}{extension}{quote}";
             return string.Join(";", segments);
         }
 
@@ -216,12 +273,24 @@ public class ProjectAnalyzer : IProjectAnalyzer
                 Guard.NotNull(environmentOptions)));
 
     /// <inheritdoc/>
-    public IAnalyzerResults Build(string targetFramework, BuildEnvironment buildEnvironment) =>
-        BuildTargets(
-            Guard.NotNull(buildEnvironment),
-            targetFramework,
-            buildEnvironment.TargetsToBuild,
-            []);
+    public IAnalyzerResults Build(string targetFramework, BuildEnvironment buildEnvironment)
+    {
+        Guard.NotNull(buildEnvironment);
+
+        AnalyzerResults results = [];
+
+        // Builds that pin a target framework can't restore themselves (see Restore).
+        if (buildEnvironment.Restore && targetFramework is not null)
+        {
+            if (!Restore(buildEnvironment, results))
+            {
+                return results;
+            }
+            buildEnvironment = buildEnvironment.WithRestore(false);
+        }
+
+        return BuildTargets(buildEnvironment, targetFramework, buildEnvironment.TargetsToBuild, results);
+    }
 
     /// <inheritdoc/>
     public IAnalyzerResults Build() =>
@@ -371,7 +440,9 @@ public class ProjectAnalyzer : IProjectAnalyzer
     /// When a multi-targeted project is built without specifying a target framework,
     /// one build runs per target framework and each writes its own binlog with the
     /// target framework appended to the file name (e.g. <c>project.net8.0.binlog</c>)
-    /// so the builds don't overwrite one another.
+    /// so the builds don't overwrite one another. When restore runs as a separate
+    /// up-front invocation (any build that pins a target framework), it writes a
+    /// <c>.restore</c>-suffixed binlog (e.g. <c>project.restore.binlog</c>).
     /// </remarks>
     /// <param name="binaryLogFilePath">
     /// The binlog file path, defaulting to the project path with a <c>.binlog</c> extension.

--- a/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
+++ b/tests/Buildalyzer.Tests/Integration/SimpleProjectsFixture.cs
@@ -335,6 +335,34 @@ public class SimpleProjectsFixture
     }
 
     [Test]
+    public void MultiTargetingCleanBuildRestoresAllTargetFrameworks()
+    {
+        // Given
+        const string projectFile = @"SdkMultiTargetingProject\SdkMultiTargetingProject.csproj";
+        StringWriter log = new StringWriter();
+        IProjectAnalyzer analyzer = GetProjectAnalyzer(projectFile, log);
+
+        // When
+        // Deleting obj forces the up-front restore to produce the assets file both inner
+        // builds use; a restore pinned to a TargetFramework would write a single-framework
+        // assets file and fail the other framework's build with NETSDK1005 (#346).
+        DeleteProjectDirectory(projectFile, "obj");
+        DeleteProjectDirectory(projectFile, "bin");
+        IAnalyzerResults results = analyzer.Build();
+
+        // Then
+        results.Count.Should().Be(2, log.ToString());
+        results.OverallSuccess.Should().BeTrue(log.ToString());
+        results.Should().AllSatisfy(r => r.Succeeded.Should().BeTrue(), log.ToString());
+
+        // Restore runs once as a separate unpinned invocation; the pinned per-TFM builds
+        // must not carry the -restore switch (it would restore the inner build).
+        string logContent = log.ToString();
+        logContent.Split("/target:Restore").Length.Should().Be(2, "restore should run exactly once");
+        logContent.Should().NotContain("/restore ");
+    }
+
+    [Test]
     public void SolutionDirShouldEndWithDirectorySeparator()
     {
         // Given

--- a/tests/Buildalyzer.Tests/ProjectAnalyzer_specs.cs
+++ b/tests/Buildalyzer.Tests/ProjectAnalyzer_specs.cs
@@ -2,20 +2,21 @@ using Buildalyzer;
 
 namespace ProjectAnalyzer_specs;
 
-public class Per_TFM_binary_log_paths
+public class Suffixed_binary_log_paths
 {
     [TestCase("project.binlog", "net8.0", "project.net8.0.binlog")]
     [TestCase(@"C:\logs\project.binlog;ProjectImports=Embed", "net8.0", @"C:\logs\project.net8.0.binlog;ProjectImports=Embed")]
     [TestCase("ProjectImports=None;LogFile=project.binlog", "net462", "ProjectImports=None;LogFile=project.net462.binlog")]
     [TestCase("LogFile=\"my project.binlog\"", "net8.0", "LogFile=\"my project.net8.0.binlog\"")]
-    public void rewrite_only_the_log_file_segment(string parameters, string targetFramework, string expected)
-        => ProjectAnalyzer.AddTargetFrameworkToBinaryLogPath(parameters, targetFramework)
+    [TestCase("project.binlog", "restore", "project.restore.binlog")]
+    public void rewrite_only_the_log_file_segment(string parameters, string suffix, string expected)
+        => ProjectAnalyzer.AddSuffixToBinaryLogPath(parameters, suffix)
             .Should().Be(expected);
 
     [TestCase("", "net8.0")]
     [TestCase("ProjectImports=None", "net8.0")]
     [TestCase("OmitInitialInfo;ProjectImports=ZipFile", "net8.0")]
-    public void leave_parameters_without_a_log_file_untouched(string parameters, string targetFramework)
-        => ProjectAnalyzer.AddTargetFrameworkToBinaryLogPath(parameters, targetFramework)
+    public void leave_parameters_without_a_log_file_untouched(string parameters, string suffix)
+        => ProjectAnalyzer.AddSuffixToBinaryLogPath(parameters, suffix)
             .Should().Be(parameters);
 }


### PR DESCRIPTION
### 🚀 Pull Request Template

## Description
This PR fixes #346: restore is a per-project (outer build) operation, but builds that pin the `TargetFramework` global property also ran `-restore` pinned, executing the inner build's restore, writing a single-framework assets file (NETSDK1005 for the other frameworks), and re-running restore once per framework. Pinned-TFM builds (multi-targeted `Build()` and the `Build(targetFramework)` overloads) now run a single up-front `-t:Restore` invocation without `TargetFramework` and drop the `-restore` switch, short-circuiting with the restore diagnostics if restore fails; unpinned builds keep inline `-restore`. Unlike the approach reverted in cee6cd7 (restore inside the first pinned invocation), the up-front restore is never pinned, so its assets file covers every framework. The separate restore writes a `.restore`-suffixed binlog so it doesn't overwrite build binlogs, and `BuildEnvironment` regains `WithRestore()` (with `NoAutoResponse` now preserved by both clone methods). A new integration test reproduces the clean-build NETSDK1005 scenario and asserts restore runs exactly once with no `/restore` on the pinned builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)